### PR TITLE
Add more detailed instructions, vm creation step and a minor fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,6 @@ image_gallery_image_version:
 			$(AZURE_RESOURCE_GROUP_NAME) \
 			$(AZURE_DISK_NAME)
 
-
 .PHONY: azure_vm
 
 azure_vm:
@@ -56,7 +55,6 @@ azure_vm:
 		exit 1 ; \
 	fi
 	source $(functions_file_path) ; create_azure_vm
-
 
 .PHONY: run
 

--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,9 @@ azure_vm:
 	fi
 	source $(functions_file_path) ; create_azure_vm
 
-.PHONY: run
+.PHONY: local_vm
 
-run:
+local_vm:
 	# https://ubuntu.com/core/docs/testing-with-qemu
 	qemu-system-x86_64 \
 		-enable-kvm \

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,41 @@ image_gallery_image_version:
 	fi
 	source $(functions_file_path) ; \
 		create_image_gallery_image_version \
-			$(makefile_directory_path)/pc.img \
-			$(makefile_directory_path)/pc.vhd \
+			$(makefile_directory_path)/azure.img \
+			$(makefile_directory_path)/azure.vhd \
 			$(AZURE_RESOURCE_GROUP_NAME) \
 			$(AZURE_DISK_NAME)
+
+
+.PHONY: azure_vm
+
+azure_vm:
+	@if [ -z "$(AZURE_RESOURCE_GROUP_NAME)" ] ; then \
+		echo "Please assign the name of the resource group in which you would like the vm to be created to the AZURE_RESOURCE_GROUP_NAME environment variable." ; \
+		exit 1 ; \
+	fi
+	@if [ -z "$(AZURE_VM_NAME)" ] ; then \
+		echo "Please assign the desired vm name to the AZURE_VM_NAME environment variable." ; \
+		exit 1 ; \
+	fi
+	source $(functions_file_path) ; create_azure_vm
+
+
+.PHONY: run
+
+run:
+	# https://ubuntu.com/core/docs/testing-with-qemu
+	qemu-system-x86_64 \
+		-enable-kvm \
+		-smp 1 \
+		-m 2048 \
+		-machine q35 \
+		-cpu host \
+		-global ICH9-LPC.disable_s3=1 \
+		-net nic,model=virtio \
+		-net user,hostfwd=tcp::8022-:22 \
+		-drive file=OVMF_CODE_4M.fd,if=pflash,format=raw,unit=0,readonly=on \
+		-drive file=OVMF_VARS_4M.ms.fd,if=pflash,format=raw,unit=1 \
+		-drive "file=azure.img",if=none,format=raw,id=disk1 \
+		-device virtio-blk-pci,drive=disk1,bootindex=1 \
+		-serial mon:stdio

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Ubuntu Core based cloud image
+# Ubuntu-Core-based cloud image
 
-This repo is used to build an Ubuntu Core based image meant to be used in an Azure VM.
+This repo is used to build an Ubuntu-Core-based image meant to be used in an Azure VM.
 
 ## Build the raw image
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,49 @@
-To build the raw image, run the following from this repository's root:
+# Ubuntu Core based cloud image
 
-```
-$ SNAPCRAFT_KEY_NAME=<name of GPG key registered with Snapcraft> GADGET_SNAP_PATH=<path to local Azure gadget snap> KERNEL_SNAP_PATH=<path to local Azure kernel snap> SNAPCRAFT_STORE_CREDENTIALS=$(cat <path to Snapcraft credentials file>) make raw_image
-```
+This repo is used to build an Ubuntu Core based image meant to be used in an Azure VM.
 
-For instructions regarding creation and registration of a GPG key for Ubuntu Core model signing (the name of which you assign to the `SNAPCRAFT_KEY_NAME` variable in the preceding command), see https://ubuntu.com/core/docs/sign-model-assertion. To build a local Azure gadget snap, see https://github.com/danpdraper/pc-gadget/tree/azure. To build a local Azure kernel snap, see https://git.launchpad.net/~ckt-core-cloud-test/+git/azure-kernel-snaps-uc24. To obtain your Snapcraft credentials (in the interest of assigning those credentials to the `SNAPCRAFT_STORE_CREDENTIALS` variable in the preceding command), see https://ubuntu.com/core/docs/create-ubuntu-one#heading--snapcraft-credentials.
+## Build the raw image
+
+1. Follow https://ubuntu.com/core/docs/sign-model-assertion to create a snapcraft key.
+2. Build a local Azure gadget snap following the instructions in https://github.com/danpdraper/pc-gadget/tree/azure
+3. Build a local kernel snap from https://git.launchpad.net/~ckt-core-cloud-test/+git/azure-kernel-snaps-uc24
+4. Export your snapcraft credentials following the instructions in https://ubuntu.com/core/docs/create-ubuntu-one#heading--snapcraft-credentials
+5. Run
+    ```bash
+    $ SNAPCRAFT_KEY_NAME=<name of snapcraft key> GADGET_SNAP_PATH=<path to local Azure gadget snap> KERNEL_SNAP_PATH=<path to local Azure kernel snap> SNAPCRAFT_STORE_CREDENTIALS=$(cat <path to Snapcraft credentials file>) make raw_image
+    ```
+
+## Modify the image
+
+WIP
+
+## Publish the image
 
 To convert the raw image to a fixed-size VHD, publish that VHD to Azure, and create an image gallery image version from that VHD, run the following from this repository's root:
 
-```
+> **Warning**
+> Use only a-z and _ characters for the Azure resource group name and disk name as the scripts concat these for the image gallery name and other characters cause issues.
+
+```bash
 $ AZURE_RESOURCE_GROUP_NAME=<name of target resource group for disk> AZURE_DISK_NAME=<name of disk> make image_gallery_image_version
+```
+
+## Create a VM
+
+```bash
+$ AZURE_RESOURCE_GROUP_NAME=<name of target resource group for disk> AZURE_VM_NAME=<name of disk> make azure_vm
+```
+
+## Connect to the VM
+
+Get the public IP of the VM from the output of the previous step or with something like:
+
+```bash
+az vm list-ip-addresses -g <resource group> -n <vm name> --query "[0].virtualMachine.network.publicIpAddresses[0].ipAddress"
+```
+
+The above should have created a new ssh key under `~/.ssh`
+
+```bash
+ssh -i ~/.ssh/1717589696_845042 -o IdentitiesOnly=yes <your username>@<public ip>
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ AZURE_RESOURCE_GROUP_NAME=<name of target resource group for disk> AZURE_VM_NA
 Get the public IP of the VM from the output of the previous step or with something like:
 
 ```bash
-az vm list-ip-addresses -g <resource group> -n <vm name> --query "[0].virtualMachine.network.publicIpAddresses[0].ipAddress"
+az vm show -d -n <vm name> -g <resource group> --query publicIps
 ```
 
 The above should have created a new ssh key under `~/.ssh`

--- a/functions.sh
+++ b/functions.sh
@@ -109,8 +109,8 @@ function create_image_version_from_disk() {
 		--os-type Linux \
 		--os-state generalized
 
-    image_timestamp=$(date --date=@$timestamp_in_seconds +'%Y.%m.%d%H%M%S')
-    timestamp=$(date --date=@$timestamp_in_seconds +'%Y%m%d%H%M%S')
+	image_timestamp=$(date --date=@$timestamp_in_seconds +'%Y.%m.%d%H%M%S')
+	timestamp=$(date --date=@$timestamp_in_seconds +'%Y%m%d%H%M%S')
 
 	az sig image-version create \
 		--resource-group $resource_group_name \
@@ -142,4 +142,3 @@ function create_azure_vm() {
 	image_def_id=$(az sig image-definition show -g "$AZURE_RESOURCE_GROUP_NAME" -r "$AZURE_RESOURCE_GROUP_NAME"_image_gallery -i "$AZURE_RESOURCE_GROUP_NAME"-image-definition --query "id" --output tsv)
 	az vm create -g "$AZURE_RESOURCE_GROUP_NAME" -n "$AZURE_VM_NAME" --image $image_def_id --size Standard_B2as_v2
 }
-

--- a/functions.sh
+++ b/functions.sh
@@ -139,7 +139,7 @@ function create_image_gallery_image_version() {
 }
 
 function create_azure_vm() {
-	image_id=$(az sig image-version list -g "$AZURE_RESOURCE_GROUP_NAME" -r "$AZURE_RESOURCE_GROUP_NAME"_image_gallery -i "$AZURE_RESOURCE_GROUP_NAME"-image-definition --query "[0].id" --output tsv)
-    az vm create -g "$AZURE_RESOURCE_GROUP_NAME" -n "$AZURE_VM_NAME" --image $image_id --size Standard_B2as_v2
+	image_def_id=$(az sig image-definition show -g "$AZURE_RESOURCE_GROUP_NAME" -r "$AZURE_RESOURCE_GROUP_NAME"_image_gallery -i "$AZURE_RESOURCE_GROUP_NAME"-image-definition --query "id" --output tsv)
+	az vm create -g "$AZURE_RESOURCE_GROUP_NAME" -n "$AZURE_VM_NAME" --image $image_def_id --size Standard_B2as_v2
 }
 


### PR DESCRIPTION
'az sig image-version create' was failing because by default the name of the disk that gets supplied to --os-snapshot has an appended timestamp.