### PR TITLE
fix disk upload to azure

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -66,7 +66,7 @@ function publish_disk() {
 		--location westeurope \
 		--zone 3 \
 		--os-type Linux \
-		--for-upload \
+		--upload-type Upload \
 		--upload-size-bytes $disk_size \
 		--sku standard_lrs \
 		--hyper-v-generation V2 || return $?

--- a/functions.sh
+++ b/functions.sh
@@ -76,7 +76,7 @@ function publish_disk() {
 			--name $full_disk_name \
 			--resource-group $resource_group_name \
 			--access-level Write \
-			--duration-in-seconds 86400 | jq --raw-output .accessSas)
+			--duration-in-seconds 86400 | jq --raw-output .accessSAS)
 
 	azcopy copy $local_disk_path $disk_access_sas_url --blob-type PageBlob || return $?
 


### PR DESCRIPTION
## fix disk upload to azure

This is how the json object is structured, which didn't match the query (with azure-cli 2.72.0):

```
  $ az disk grant-access \
      --name core24-20250515081511 \
      -g gallery-rg \
      --access-level Write \
      --duration-in-seconds 60
  {
    "accessSAS": "https://..."
  }
```

## Fix deprecation warning when uploading image

The `disk create` command raises with warning:

  Option '--for-upload' has been deprecated and will be removed in a
  future release. Use '--upload-type Upload' instead.

